### PR TITLE
Added "liblist" action to list libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@
         binlist PKG ...
             Restrict the output of 'list' to executable files.
 
+        liblist PKG ...
+            Restrict the output of 'list' to library files.
+
         etclist PKG ...
             Restrict the output of 'list' to configuration files.
 

--- a/bash_completion.d/owl
+++ b/bash_completion.d/owl
@@ -34,14 +34,14 @@ _owl()
                 ;;
         esac
         if [[ $COMP_CWORD -eq 1 ]] ; then
-            local actions='update pull install remove download info deps uses page home search query list lsgrep binlist etclist manlist doclist grep version repository description category owns cleanup leftovers foreigns orphans'
+            local actions='update pull install remove download info deps uses page home search query list lsgrep binlist liblist etclist manlist doclist grep version repository description category owns cleanup leftovers foreigns orphans'
             COMPREPLY=( $(compgen -W "$actions" -- "$current_word") )
             return 0
         else
             local second_word=${COMP_WORDS[1]}
             local packages=""
             case $second_word in
-                list | lsgrep | binlist | etclist | manlist | doclist | grep | remove | deps | uses)
+                list | lsgrep | binlist | liblist | etclist | manlist | doclist | grep | remove | deps | uses)
                     [[ $second_word == grep && $COMP_CWORD -eq 2 ]] && return 0
                     [[ $second_word == lsgrep && $COMP_CWORD -eq 2 ]] && return 0
                     packages="$(_local_packages)"

--- a/manual/owl.8
+++ b/manual/owl.8
@@ -76,6 +76,11 @@ Restrict the output of
 .B list
 to executable files.
 .TP
+.BI "liblist " "PKG " ...
+Restrict the output of
+.B list
+to library files.
+.TP
 .BI "etclist " "PKG " ...
 Restrict the output of
 .B list

--- a/owl
+++ b/owl
@@ -375,6 +375,9 @@ case $action in
     binlist)
         pacman -Qlq "$@" | grep '/s\?bin/.'
         ;;
+    liblist)
+        pacman -Qlq "$@" | grep '/lib/.'
+        ;;
     etclist)
         pacman -Qlq "$@" | grep '/etc/.'
         ;;


### PR DESCRIPTION
I like the current "binlist" but I often need to find the name of some libraries while developping, so I added a "liblist" action similar to the others but with the pattern '/lib/.' and I updated the docs and bash completion accordingly.
