### PR TITLE
Option to clean up after a build

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ The following environment variables are handled:
 
 - **OWL_COLOR_RESULTS** -- colorize search results (default value: 'true').
 
-- **OWL_IGNORE_OUTDATED** -- wether to ignore outdated AUR results (default value: 'false').
+- **OWL_IGNORE_OUTDATED** -- whether to ignore outdated AUR results (default value: 'false').
+
+- **OWL_CLEAN_UP** -- whether to clean up after a non-git build 'makepkg -c flag' (default value: 'false').
 
 - **OWL_MAX_URL** -- the maximum number of URL this program is allowed to send to
   the BROWSER in one go.

--- a/manual/owl.8
+++ b/manual/owl.8
@@ -184,6 +184,9 @@ The following environment variables are used:
 .I OWL_IGNORE_OUTDATED
 -- whether to ignore outdated AUR results (default value: 'false').
 .IP \[bu]
+.I OWL_CLEAN_UP
+-- whether to clean up after a non-git build 'makepkg -c flag' (default value: 'false').
+.IP \[bu]
 .I OWL_MAX_URL
 -- the maximum number of URL this program is allowed to send to the
 .I BROWSER

--- a/owl
+++ b/owl
@@ -6,6 +6,7 @@ BROWSER=${BROWSER:-web_browser}
 OWL_MAX_URL=${OWL_MAX_URL:-16}
 OWL_SUDO_WARN=${OWL_SUDO_WARN:-true}
 OWL_IGNORE_OUTDATED=${OWL_IGNORE_OUTDATED:-false}
+OWL_CLEAN_UP=${OWL_CLEAN_UP:-false}
 PACMAN_LOG="/var/log/pacman.log"
 
 usage() {
@@ -355,7 +356,11 @@ case $action in
                     list_of_programs=$(cat "$tmp_out" | tac | sed 's/.* \([^ ]\+\) downloaded.*/\1/') 
                     for pkgname in $list_of_programs; do
                         cd "$XDG_AUR_HOME/$pkgname"
-                        makepkg -ifs
+                        if [ "$OWL_CLEAN_UP" = "true" ] ; then
+                            makepkg -ifsc
+                        else
+                            makepkg -ifs
+                        fi
                         [ $? -ne 0 ] && exit 1
                     done
                     : > "$tmp_out"


### PR DESCRIPTION
OWL_CLEAN_UP can be set to true to use makepkg -c flag on install.

For git builds we don't want to clean up after the build since that
limits the usefulness of 'owl pull'.
