### PR TITLE
update action should run against sync repos and AUR by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The actions on which each option applies are given between parenthesis.
 
 - **-a, --aur** -- restrain the action to the AUR packages (*update*, *search*).
 
-- **-o, --repo** -- restrain the action to the sync packages (*search*).
+- **-o, --repo** -- restrain the action to the sync packages (*update*, *search*).
 
 - **-l, --local** -- restrain the action to the local packages (*info*, *deps*, *uses*, *version*, *repository*, *category*, *description*).
 

--- a/manual/owl.8
+++ b/manual/owl.8
@@ -149,7 +149,7 @@ Provide extended informations.
 .BR -a ,\  --aur "  (update, search)"
 Restrain the action to the AUR packages.
 .TP
-.BR -o ,\  --repo "  (search)"
+.BR -o ,\  --repo "  (update, search)"
 Restrain the action to the sync packages.
 .TP
 .BR -l ,\  --local "  (info, deps, uses, version, repository, category, description)"

--- a/owl
+++ b/owl
@@ -45,6 +45,11 @@ warning() {
     white " $@"
 }
 
+info() {
+    green "==>"
+    white " $@"
+}
+
 sudorun() {
     if [ "$OWL_SUDO_WARN" = "true" ] ; then
         warning "Running sudo"
@@ -186,7 +191,14 @@ shift $(($OPTIND - 1))
 
 case $action in
     update)
-        if [ $aur_only -eq 1 ] ; then
+        if [ $aur_only -ne 1 ]; then
+            info "Checking sync repos for updates"
+            printf "\n"
+            sudorun pacman -Syu
+        fi
+        if [ $repo_only -ne 1 ] ; then
+            info "Checking AUR for updates"
+            printf "\n"
             cower -u | tee "$tmp_out"
             if [ -s "$tmp_out" ] ; then
                     printf "reinstall packages? [Y/n] "
@@ -197,9 +209,9 @@ case $action in
                             owl install $(cat "$tmp_out" | sed 's/^:: *\([^ ]\+\) .*$/\1/' | xargs)
                             ;;
                     esac
+            else
+                printf "%s\n" "No AUR updates found"
             fi
-        else
-            sudorun pacman -Syu
         fi
         ;;
     pull)


### PR DESCRIPTION
Change the update action to run against both the sync repos and the AUR
by default. The -o and -a flags can restrict the update action to the
sync repos or the AUR respectively.
